### PR TITLE
Change navbar link text if session has expired

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,12 @@ import ForgotPassword from './components/screens/ForgotPassword';
 
 const App = () => {
     const [showLoader, setShowLoader] = useState(false);
+    const [sessionExpired, setSessionExpired] = useState(false);
+
+    // Change the navbar login link text in the case that the user's session has expired, but the authToken is still in local storage.
+    function sessionExpiredCallback(data) {
+      setSessionExpired(data);
+    }
 
     //Loader for urlSearch
     function loaderCallback(data) {
@@ -44,6 +50,8 @@ const App = () => {
       )}
       <Navbar
         loaderCallback={loaderCallback}
+        sessionExpired={sessionExpired}
+        sessionExpiredCallback={sessionExpiredCallback}
       />
       <Routes>
         <Route 
@@ -57,14 +65,15 @@ const App = () => {
         element={<Edit />} />
         <Route
           path="/login"
-          element={<LoginScreen  />}
+          element={<LoginScreen
+            sessionExpiredCallback={sessionExpiredCallback}  />}
         />
         <Route 
         path="/register" 
         element={<RegisterScreen />} />
         <Route
           path="/private"
-          element={<PrivateScreen />}
+          element={<PrivateScreen sessionExpiredCallback={sessionExpiredCallback} />}
         />
         <Route 
         path="/forgotpassword" 

--- a/client/src/components/navbar.js
+++ b/client/src/components/navbar.js
@@ -1,18 +1,13 @@
-import { React } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { React, useState } from 'react';
+import { Link, useNavigate, NavLink } from 'react-router-dom';
 
 // We import bootstrap to make our application look better.
 import 'bootstrap/dist/css/bootstrap.css';
 import '../index.css';
-
-
-// We import NavLink to utilize the react router.
-import { NavLink } from 'react-router-dom';
 import UrlSearch from './urlSearch';
 
 // Here, we display our Navbar
 const Navbar = (props) => {
-
   const navigate = useNavigate();
 
   const handleLogout = () => {
@@ -20,6 +15,8 @@ const Navbar = (props) => {
     localStorage.removeItem('userId');
     navigate('/login');
   };
+
+  console.log(props.sessionExpired);
 
   return (
     <div className="disable-while-loading">
@@ -39,7 +36,7 @@ const Navbar = (props) => {
           <span className="navbar-toggler-icon"></span>
         </button>
         <div className="collapse navbar-collapse" id="navbarSupportedContent">
-          {localStorage.getItem('authToken') ? (
+          {(!props.sessionExpired && localStorage.getItem('authToken')) ? (
             <div>
               <ul className="navbar-nav ml-auto">
                 <li className="nav-item">
@@ -59,7 +56,10 @@ const Navbar = (props) => {
                   />
                 </li>
                 <li className="nav-item">
-                  <Link className="nav-link" to="login" onClick={handleLogout}>
+                  <Link className="nav-link" to="login" onClick={() => {
+                    handleLogout();
+                    props.sessionExpiredCallback(true);
+                  }}>
                     Logout
                   </Link>
                 </li>
@@ -67,7 +67,7 @@ const Navbar = (props) => {
             </div>
           ) : (
             <Link className="login-link" to="login">
-              Register / Sign In
+              Register / Login
             </Link>
           )}
         </div>

--- a/client/src/components/screens/LoginScreen.js
+++ b/client/src/components/screens/LoginScreen.js
@@ -33,6 +33,7 @@ const LoginScreen = (props) => {
       );
 
       localStorage.setItem('authToken', data.token);
+      props.sessionExpiredCallback(false);
 
       navigate("/private");
     } catch (error) {

--- a/client/src/components/screens/PrivateScreen.js
+++ b/client/src/components/screens/PrivateScreen.js
@@ -37,6 +37,7 @@ const PrivateScreen = (props) => {
       } catch (error) {
         localStorage.removeItem('authToken');
         localStorage.removeItem('userId');
+        props.sessionExpiredCallback(true);
         setError('You are not authorized please login');
         console.log(error);
       }


### PR DESCRIPTION
If the user's token has expired but the authToken still resides in localstorage, the next attempt to access /private will redirect to /login.

However, <Navbar /> will read that there is an authToken, and show "logout", whereas, it should say "Register / Sign In".

Solution: Create a stateful variable that will tell whether the session is expired and make the login/logout link text contingent upon that variable.

**Question:** Why doesn't Navbar rerender? Because Navbar is a sibling of /login or /parent, so will not rerender just because the siblings rerender.